### PR TITLE
Breaking: Rename RelabelReferenceNames to UpdateDataContigNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ There are three ways to initialize IGV:
 
 This tool will always attempt to connect to a running IGV application before attempting to start a new instance of IGV.
 Provide a path to an IGV JAR file if no IGV applications are currently running.
-If no IGV JAR file path is set, and there are no running instances of IGV, then this tool will attempt to fnd 'igv' on the system PATH and execute the application.
+If no IGV JAR file path is set, and there are no running instances of IGV, then this tool will attempt to fnd `igv` on the system path and execute the application.
 
 You can shutdown IGV on exit with the `--close-on-exit` option.
 This will work regardless of how this tool initially connected to IGV and is handy for tearing down the application after your investigation is concluded.
@@ -123,9 +123,9 @@ Then go to two loci by name that are referenced in the first two name fields of 
 ❯ cvbio IgvBoss -g mm10.fa -i infile.bam targets.bed -l $(cut -f4 < targets.bed | head -n2)
 ```
 
-## RelabelReferenceNames
+## UpdateDataContigNames
 
-Relabel reference sequence names in delimited data using a chromosome name mapping table.
+Update contig names in delimited data using a name mapping table.
 
 A collection of mapping tables is maintained at the following location:
 
@@ -135,23 +135,22 @@ A collection of mapping tables is maintained at the following location:
 
 - Optionally drop rows which have chromosome names not in the mapping file
 - Replace multiple fields in a row at once using the same mapping file
-- Directly write-out rows that startwith arbitrary strings (default of `#`)
+- Directly write-out rows that start with arbitrary strings (default of `#`)
 - Parses any delimited data using any single character delimiter
 
 #### Command Line Usage
 
-Relabel the chromosomes names in a human gene annotation file.
+Relabel the contig names in an Ensembl human gene annotation file.
 
 ```console
 ❯ git clone https://github.com/dpryan79/ChromosomeMappings.git
-❯ wget -qO- ftp://ftp.ensembl.org/pub/release-96/gtf/homo_sapiens/Homo_sapiens.GRCh38.96.gtf.gz \
-    | gzip -dc > Homo_sapiens.GRCh38.96.gtf
+❯ wget ftp://ftp.ensembl.org/pub/release-96/gtf/homo_sapiens/Homo_sapiens.GRCh38.96.gtf.gz
 
-❯ cvbio RelabelReferenceNames \
-    -i Homo_sapiens.GRCh38.96.gtf \
-    -o Homo_sapiens.GRCh38.96.ucsc-named.gtf \
+❯ cvbio UpdateDataContigNames \
+    -i Homo_sapiens.GRCh38.96.gtf.gz \
+    -o Homo_sapiens.GRCh38.96.ucsc-named.gtf.gz \
     -m ChromosomeMappings/GRCh38_ensembl2UCSC.txt \
-    --skip-prefixes '#' \
+    --comment-chars '#' \
     --columns 0 \
-    --drop false
+    --skip-missing false
 ```

--- a/tools/src/io/cvbio/tools/cmdline/ClpGroups.scala
+++ b/tools/src/io/cvbio/tools/cmdline/ClpGroups.scala
@@ -5,6 +5,11 @@ import com.fulcrumgenomics.sopt.cmdline.ClpGroup
 /** The command line groups. */
 object ClpGroups {
 
+  class _Deprecated extends ClpGroup {
+    override val name: String = "Deprecated"
+    override val description: String = "These are provided for compatibility between major version upgrades."
+  }
+
   class _SamOrBam extends ClpGroup {
     override val name: String = "SAM/BAM"
     override val description: String = "Tools for manipulating SAM, BAM, and related data."
@@ -15,6 +20,7 @@ object ClpGroups {
     override val description: String = "Utility programs."
   }
 
-  final val SamOrBam = classOf[_SamOrBam]
-  final val Util     = classOf[_Util]
+  final val Deprecated = classOf[_Deprecated]
+  final val SamOrBam   = classOf[_SamOrBam]
+  final val Util       = classOf[_Util]
 }

--- a/tools/src/io/cvbio/tools/cmdline/ClpGroups.scala
+++ b/tools/src/io/cvbio/tools/cmdline/ClpGroups.scala
@@ -7,7 +7,7 @@ object ClpGroups {
 
   class _Deprecated extends ClpGroup {
     override val name: String = "Deprecated"
-    override val description: String = "These are provided for compatibility between major version upgrades."
+    override val description: String = "These tools are provided for compatibility between major version upgrades."
   }
 
   class _SamOrBam extends ClpGroup {

--- a/tools/src/io/cvbio/tools/util/RelabelReferenceNames.scala
+++ b/tools/src/io/cvbio/tools/util/RelabelReferenceNames.scala
@@ -8,6 +8,8 @@ import io.cvbio.tools.cmdline.ClpGroups
 @clp(
   description =
     """
+      |Deprecated: Use `UpdateDataContigNames` instead.
+      |
       |Relabel reference sequence names in delimited data using a chromosome name mapping table.
       |
       |A collection of mapping tables is maintained at the following location:

--- a/tools/src/io/cvbio/tools/util/RelabelReferenceNames.scala
+++ b/tools/src/io/cvbio/tools/util/RelabelReferenceNames.scala
@@ -1,14 +1,10 @@
 package io.cvbio.tools.util
 
-import com.fulcrumgenomics.commons.util.DelimitedDataParser
 import com.fulcrumgenomics.sopt._
-import com.fulcrumgenomics.util.Io
 import io.cvbio.commons.CommonsDef._
-import io.cvbio.tools.cmdline.{ClpGroups, CvBioTool}
-import io.cvbio.tools.util.RelabelReferenceNames.{DefaultDelimiter, SkipLinePrefixes}
+import io.cvbio.tools.cmdline.ClpGroups
 
-import scala.util.Properties.lineSeparator
-
+@deprecated(message = "Use `UpdateDataContigNames` instead.", since = "2.0.0")
 @clp(
   description =
     """
@@ -18,67 +14,20 @@ import scala.util.Properties.lineSeparator
       |
       | - https://github.com/dpryan79/ChromosomeMappings
     """,
-  group = ClpGroups.Util
+  group = ClpGroups.Deprecated
 ) class RelabelReferenceNames(
-  @arg(flag = 'i', doc = "The input file.") val in: FilePath,
-  @arg(flag = 'o', doc = "The output file.") val out: FilePath,
+  @arg(flag = 'i', doc = "The input file.") override val in: FilePath,
+  @arg(flag = 'o', doc = "The output file.") override val out: FilePath,
   @arg(flag = 'm', doc = "A two-column tab-delimited mapping file.") val mappingFile: FilePath,
-  @arg(flag = 'c', doc = "The column names to convert, 0-indexed.", minElements = 1) val columns: Seq[Int] = Seq(0),
-  @arg(flag = 'd', doc = "The input file data delimiter.") val delimiter: Char = DefaultDelimiter,
-  @arg(flag = 's', doc = "Directly write-out columns that start with these prefixes.") val skipPrefixes: Seq[String] = SkipLinePrefixes,
+  @arg(flag = 'c', doc = "The column names to convert, 0-indexed.", minElements = 1) override val columns: Seq[Int] = Seq(0),
+  @arg(flag = 'd', doc = "The input file data delimiter.") override val delimiter: Char = '\t',
+  @arg(flag = 's', doc = "Directly write-out columns that start with these prefixes.") val skipPrefixes: Seq[String] = Seq("#"),
   @arg(flag = 'x', doc = "Drop records which do not have a mapping.") val drop: Boolean = true
-) extends CvBioTool {
+) extends UpdateDataContigNames(in, out, mappingFile, columns, delimiter, skipPrefixes, drop) {
 
   /** Run the tool [[RelabelReferenceNames]]. */
   override def execute(): Unit = {
-    val source = Io.toSource(in)
-    val writer = Io.toWriter(out)
-    val lookup = RelabelReferenceNames.buildMapping(mappingFile, delimiter = DefaultDelimiter)
-
-    source.getLines.zipWithIndex.foreach { case (line: String, i: Int) =>
-      if (skipPrefixes.exists(line.startsWith)) {
-        writer.write(line + lineSeparator)
-      } else {
-        val fields  = line.split(delimiter)
-        val isValid = columns.map(fields).forall(lookup.keysIterator.contains)
-        if (isValid) {
-          val patched = patchManyWith(fields, at = columns, using = lookup)
-          writer.write(patched.mkString(delimiter.toString) + lineSeparator)
-        } else if (drop && !isValid) {
-          logger.info(s"A field in record ${i + 1} did not have a mapping: $line")
-        } else {
-          throw new NoSuchElementException(s"A field in record ${i + 1} did not have a mapping: $line")
-        }
-      }
-    }
-    source.safelyClose()
-    writer.close()
-  }
-}
-
-/** Companion object for [[RelabelReferenceNames]]. */
-object RelabelReferenceNames {
-
-  /** The default delimiter to use for most text files. */
-  val DefaultDelimiter: Char = '\t'
-
-  /** Skip lines with these prefixes. */
-  val SkipLinePrefixes: Seq[String] = Seq("#")
-
-  /** Build a reference sequence name mapping. */
-  private[util] def buildMapping(lines: Iterator[String], delimiter: Char = DefaultDelimiter): Map[String, String] = {
-    val rows = new DelimitedDataParser(lines, delimiter = delimiter, header = Seq("1", "2"))
-    rows.map { row => row[String](index = 0) -> row[String](index = 1) }.toMap
-  }
-
-  /** Build a reference sequence name mapping. */
-  private[util] def buildMapping(file: FilePath, delimiter: Char): Map[String, String] = {
-    buildMapping(Io.toSource(file).getLines(), delimiter = delimiter)
-  }
-
-  /** Relabel a line of delimited data using the function <using> for each index in <at>. */
-  private[util] def relabel(line: String, at: Seq[Int], delimiter: Char = DefaultDelimiter, using: String => String): String = {
-    val patched = patchManyWith(line.split(delimiter), at, using)
-    patched.mkString(delimiter.toString)
+    logger.warning("This tool is deprecated, please use `UpdateDataContigNames` instead.")
+    super.execute()
   }
 }

--- a/tools/src/io/cvbio/tools/util/UpdateDataContigNames.scala
+++ b/tools/src/io/cvbio/tools/util/UpdateDataContigNames.scala
@@ -1,0 +1,93 @@
+package io.cvbio.tools.util
+
+import com.fulcrumgenomics.commons.util.DelimitedDataParser
+import com.fulcrumgenomics.sopt._
+import com.fulcrumgenomics.util.{Io, ProgressLogger}
+import io.cvbio.commons.CommonsDef._
+import io.cvbio.tools.cmdline.{ClpGroups, CvBioTool}
+import io.cvbio.tools.util.UpdateDataContigNames.{CommentLinePrefixes, DefaultDelimiter}
+
+import scala.util.Properties.lineSeparator
+
+@clp(
+  description =
+    """
+      |Update contig names in delimited data using a name mapping table.
+      |
+      |A collection of mapping tables is maintained at the following location:
+      |
+      | - https://github.com/dpryan79/ChromosomeMappings
+    """,
+  group = ClpGroups.Util
+) class UpdateDataContigNames(
+  @arg(flag = 'i', doc = "The input file.") val in: FilePath,
+  @arg(flag = 'o', doc = "The output file.") val out: FilePath,
+  @arg(flag = 'm', doc = "A two-column tab-delimited mapping file.") val mapping: FilePath,
+  @arg(flag = 'c', doc = "The column names to convert, 0-indexed.", minElements = 1) val columns: Seq[Int] = Seq(0),
+  @arg(flag = 'd', doc = "The input file data delimiter.") val delimiter: Char = DefaultDelimiter,
+  @arg(flag = 'C', doc = "Directly write-out lines that start with these prefixes.") val commentChars: Seq[String] = CommentLinePrefixes,
+  @arg(flag = 's', doc = "Skip (ignore) records which do not have a mapping.") val skipMissing: Boolean = true
+) extends CvBioTool {
+
+  /** Run the tool [[UpdateDataContigNames]]. */
+  override def execute(): Unit = {
+    val source   = Io.toSource(in)
+    val writer   = Io.toWriter(out)
+    val progress = ProgressLogger(logger)
+    val lookup   = UpdateDataContigNames.buildMapping(mapping, delimiter = DefaultDelimiter)
+
+    source.getLines.zipWithIndex.foreach { case (line: String, i: Int) =>
+      if (commentChars.exists(line.startsWith)) {
+        writer.write(line + lineSeparator)
+      } else {
+        val fields  = line.split(delimiter)
+        val isValid = columns.map(fields).forall(lookup.keysIterator.contains)
+        if (isValid) {
+          val patched = patchManyWith(fields, at = columns, using = lookup)
+          writer.write(patched.mkString(delimiter.toString) + lineSeparator)
+        } else if (skipMissing && !isValid) {
+          logger.info(s"A field in record ${i + 1} did not have a mapping: $line")
+        } else {
+          throw new NoSuchElementException(s"A field in record ${i + 1} did not have a mapping: $line")
+        }
+      }
+      progress.record()
+    }
+    progress.logLast()
+    source.safelyClose()
+    writer.close()
+  }
+}
+
+/** Companion object for [[UpdateDataContigNames]]. */
+object UpdateDataContigNames {
+
+  /** The default delimiter to use for most text files. */
+  val DefaultDelimiter: Char = '\t'
+
+  /** Skip lines with these prefixes and treat them as comments. */
+  val CommentLinePrefixes: Seq[String] = Seq("#")
+
+  /** Build a reference sequence name mapping. */
+  private[util] def buildMapping(lines: Iterator[String], delimiter: Char = DefaultDelimiter): Map[String, String] = {
+    val rows = new DelimitedDataParser(lines, delimiter = delimiter, header = Seq("1", "2"))
+    rows.map { row => row[String](index = 0) -> row[String](index = 1) }.toMap
+  }
+
+  /** Build a reference sequence name mapping. */
+  private[util] def buildMapping(file: FilePath, delimiter: Char): Map[String, String] = {
+    buildMapping(Io.toSource(file).getLines(), delimiter = delimiter)
+  }
+
+  /** Update a line of delimited data using the function <using> for each index in <at>.
+    *
+    * @param line a sequence of delimited data
+    * @param at the indexes (0-based) of <line> split by <delimiter> where we will update contig/chromosome names
+    * @param delimiter the delimiter for the data in <line>
+    * @param using a method for updating contig/chromosome names
+    */
+  def update(line: String, at: Seq[Int], delimiter: Char = DefaultDelimiter, using: String => String): String = {
+    val patched = patchManyWith(line.split(delimiter), at, using)
+    patched.mkString(delimiter.toString)
+  }
+}

--- a/tools/test/src/io/cvbio/tools/util/UpdateDataContigNamesTest.scala
+++ b/tools/test/src/io/cvbio/tools/util/UpdateDataContigNamesTest.scala
@@ -60,13 +60,13 @@ class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
     val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter)
-    update.execute()
+    captureLogger { () => update.execute() }
 
     val actual = Io.readLines(outfile).map(_.split(Delimiter)).toList
     actual should contain theSameElementsInOrderAs expected
   }
 
-  it should "raise an exception by default if a lookup function fails and drop is false" in {
+  it should "raise an exception by default if a lookup function fails and skip missing is false" in {
     val original = Seq(Seq("chr1", "2", "3"), Seq("chr4", "4", "5"), Seq("illegal", "5", "6"))
 
     val infile   = tempFile()
@@ -77,7 +77,7 @@ class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
     a[NoSuchElementException] shouldBe thrownBy { update.execute() }
   }
 
-  it should "drop any records with items not in the mapping when drop is true" in {
+  it should "skip any records with items not in the mapping when skip missing is true" in {
     val original = Seq(Seq("chr1", "2", "3"), Seq("chr4", "4", "5"), Seq("illegal", "5", "6"))
     val expected = Seq(Seq("1", "2", "3"), Seq("4", "4", "5"))
 
@@ -92,7 +92,7 @@ class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
     actual should contain theSameElementsInOrderAs expected
   }
 
-  it should "drop any records with items not in the mapping when skip missing is true, but not lines starting with a skip prefix" in {
+  it should "skip any records with items not in the mapping when skip missing is true, but not lines starting with a skip prefix" in {
     val original = Seq(Seq("chr1", "2", "3"), Seq("# comment"), Seq("chr4", "4", "5"), Seq("illegal", "5", "6"))
     val expected = Seq(Seq("1", "2", "3"), Seq("# comment"), Seq("4", "4", "5"))
 
@@ -118,7 +118,7 @@ class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
     val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter, commentChars = skipPrefixes)
-    update.execute()
+    captureLogger { () => update.execute() }
 
     val actual = Io.readLines(outfile).map(_.split(Delimiter)).toList
     actual should contain theSameElementsInOrderAs expected

--- a/tools/test/src/io/cvbio/tools/util/UpdateDataContigNamesTest.scala
+++ b/tools/test/src/io/cvbio/tools/util/UpdateDataContigNamesTest.scala
@@ -6,7 +6,7 @@ import com.fulcrumgenomics.commons.util.CaptureSystemStreams
 import io.cvbio.commons.effectful.Io
 import io.cvbio.testing.UnitSpec
 
-class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
+class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
 
   /** Default delimiter for tests. */
   val Delimiter: Char = '\t'
@@ -24,34 +24,34 @@ class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
     file
   }
 
-  "RelabelReferenceNames.relabel" should "successfully relabel a valid column position" in {
+  "UpdateDataContigNames.relabel" should "successfully relabel a valid column position" in {
     val line     = Seq("chr1", "200030", "400000", "interval-name").mkString(Delimiter.toString)
     val expected = Seq("1", "200030", "400000", "interval-name").mkString(Delimiter.toString)
-    val actual   = RelabelReferenceNames.relabel(line, Seq(0), Delimiter, Hg38UcscToEnsemblAutosomes)
+    val actual   = UpdateDataContigNames.update(line, Seq(0), Delimiter, Hg38UcscToEnsemblAutosomes)
     actual shouldBe expected
   }
 
   it should "successfully relabel multiple valid column positions" in {
     val line     = Seq("chr1", "chr2", "chr3", "chr4").mkString(Delimiter.toString)
     val expected = Seq("1", "2", "3", "chr4").mkString(Delimiter.toString)
-    val actual   = RelabelReferenceNames.relabel(line, Seq(0, 1, 2), Delimiter, Hg38UcscToEnsemblAutosomes)
+    val actual   = UpdateDataContigNames.update(line, Seq(0, 1, 2), Delimiter, Hg38UcscToEnsemblAutosomes)
     actual shouldBe expected
   }
 
   it should "raise an exception by default if a lookup function fails" in {
     val line = Seq("chr29", "200030", "400000", "interval-name").mkString(Delimiter.toString)
-    an[NoSuchElementException] shouldBe thrownBy { RelabelReferenceNames.relabel(line, Seq(0), Delimiter, Hg38UcscToEnsemblAutosomes) }
+    an[NoSuchElementException] shouldBe thrownBy { UpdateDataContigNames.update(line, Seq(0), Delimiter, Hg38UcscToEnsemblAutosomes) }
   }
 
-  "RelabelReferenceNames.buildMapping" should "read a mapping from an iterator of lines" in {
-    RelabelReferenceNames.buildMapping(MappingLines.iterator, Delimiter) shouldBe Hg38UcscToEnsemblAutosomes
+  "UpdateDataContigNames.buildMapping" should "read a mapping from an iterator of lines" in {
+    UpdateDataContigNames.buildMapping(MappingLines.iterator, Delimiter) shouldBe Hg38UcscToEnsemblAutosomes
   }
 
   it should "read a mapping from two-column delimited file" in {
-    RelabelReferenceNames.buildMapping(MappingFile, Delimiter) shouldBe Hg38UcscToEnsemblAutosomes
+    UpdateDataContigNames.buildMapping(MappingFile, Delimiter) shouldBe Hg38UcscToEnsemblAutosomes
   }
 
-  "RelabelReferenceNames" should "relabel a text file" in {
+  "UpdateDataContigNames" should "relabel a text file" in {
     val original = Seq(Seq("chr1", "2", "3"), Seq("chr4", "4", "5"))
     val expected = Seq(Seq("1", "2", "3"), Seq("4", "4", "5"))
 
@@ -59,8 +59,8 @@ class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
     val outfile  = tempFile()
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
-    val relabel = new RelabelReferenceNames(infile, outfile, MappingFile, columns = Seq(0), delimiter = Delimiter)
-    relabel.execute()
+    val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter)
+    update.execute()
 
     val actual = Io.readLines(outfile).map(_.split(Delimiter)).toList
     actual should contain theSameElementsInOrderAs expected
@@ -73,8 +73,8 @@ class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
     val outfile  = tempFile()
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
-    val relabel = new RelabelReferenceNames(infile, outfile, MappingFile, columns = Seq(0), delimiter = Delimiter, drop = false)
-    a[NoSuchElementException] shouldBe thrownBy { relabel.execute() }
+    val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter, skipMissing = false)
+    a[NoSuchElementException] shouldBe thrownBy { update.execute() }
   }
 
   it should "drop any records with items not in the mapping when drop is true" in {
@@ -85,14 +85,14 @@ class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
     val outfile  = tempFile()
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
-    val relabel = new RelabelReferenceNames(infile, outfile, MappingFile, columns = Seq(0), delimiter = Delimiter, drop = true)
-    noException shouldBe thrownBy { captureLogger { () => relabel.execute() } }
+    val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter, skipMissing = true)
+    noException shouldBe thrownBy { captureLogger { () => update.execute() } }
 
     val actual = Io.readLines(outfile).map(_.split(Delimiter)).toList
     actual should contain theSameElementsInOrderAs expected
   }
 
-  it should "drop any records with items not in the mapping when drop is true, but not lines starting with a skip prefix" in {
+  it should "drop any records with items not in the mapping when skip missing is true, but not lines starting with a skip prefix" in {
     val original = Seq(Seq("chr1", "2", "3"), Seq("# comment"), Seq("chr4", "4", "5"), Seq("illegal", "5", "6"))
     val expected = Seq(Seq("1", "2", "3"), Seq("# comment"), Seq("4", "4", "5"))
 
@@ -100,14 +100,14 @@ class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
     val outfile  = tempFile()
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
-    val relabel = new RelabelReferenceNames(infile, outfile, MappingFile, columns = Seq(0), delimiter = Delimiter, drop = true)
-    noException shouldBe thrownBy { captureLogger { () => relabel.execute() } }
+    val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter, skipMissing = true)
+    noException shouldBe thrownBy { captureLogger { () => update.execute() } }
 
     val actual = Io.readLines(outfile).map(_.split(Delimiter)).toList
     actual should contain theSameElementsInOrderAs expected
   }
 
-  it should "write-out records with skip characters directly to the output file" in {
+  it should "write-out records with comment characters as prefixes, directly to the output file" in {
     val skipPrefixes = Seq("#", "track")
 
     val original = Seq(Seq("chr1", "2", "3"), Seq("# this is a comment"), Seq("track: this is a track"), Seq("chr4", "4", "5"))
@@ -117,8 +117,8 @@ class RelabelReferenceNamesTest extends UnitSpec with CaptureSystemStreams {
     val outfile  = tempFile()
     Io.writeLines(infile, original.map(_.mkString(Delimiter.toString)))
 
-    val relabel = new RelabelReferenceNames(infile, outfile, MappingFile, columns = Seq(0), delimiter = Delimiter, skipPrefixes = skipPrefixes)
-    relabel.execute()
+    val update = new UpdateDataContigNames(infile, outfile, mapping = MappingFile, columns = Seq(0), delimiter = Delimiter, commentChars = skipPrefixes)
+    update.execute()
 
     val actual = Io.readLines(outfile).map(_.split(Delimiter)).toList
     actual should contain theSameElementsInOrderAs expected

--- a/tools/test/src/io/cvbio/tools/util/UpdateDataContigNamesTest.scala
+++ b/tools/test/src/io/cvbio/tools/util/UpdateDataContigNamesTest.scala
@@ -24,14 +24,14 @@ class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
     file
   }
 
-  "UpdateDataContigNames.relabel" should "successfully relabel a valid column position" in {
+  "UpdateDataContigNames.update" should "successfully update a valid column position" in {
     val line     = Seq("chr1", "200030", "400000", "interval-name").mkString(Delimiter.toString)
     val expected = Seq("1", "200030", "400000", "interval-name").mkString(Delimiter.toString)
     val actual   = UpdateDataContigNames.update(line, Seq(0), Delimiter, Hg38UcscToEnsemblAutosomes)
     actual shouldBe expected
   }
 
-  it should "successfully relabel multiple valid column positions" in {
+  it should "successfully update multiple valid column positions" in {
     val line     = Seq("chr1", "chr2", "chr3", "chr4").mkString(Delimiter.toString)
     val expected = Seq("1", "2", "3", "chr4").mkString(Delimiter.toString)
     val actual   = UpdateDataContigNames.update(line, Seq(0, 1, 2), Delimiter, Hg38UcscToEnsemblAutosomes)
@@ -51,7 +51,7 @@ class UpdateDataContigNamesTest extends UnitSpec with CaptureSystemStreams {
     UpdateDataContigNames.buildMapping(MappingFile, Delimiter) shouldBe Hg38UcscToEnsemblAutosomes
   }
 
-  "UpdateDataContigNames" should "relabel a text file" in {
+  "UpdateDataContigNames" should "update a text file" in {
     val original = Seq(Seq("chr1", "2", "3"), Seq("chr4", "4", "5"))
     val expected = Seq(Seq("1", "2", "3"), Seq("4", "4", "5"))
 


### PR DESCRIPTION
Closes #64 because we use [`com.fulcrumgenomics.util.Io.scala`](https://github.com/fulcrumgenomics/fgbio/blob/11a4b9e43da87bc2164f25191fd1f145030b6e82/src/main/scala/com/fulcrumgenomics/util/Io.scala#L42-L59).

This PR's breaking changes was motivated by an in-progress PR here: https://github.com/fulcrumgenomics/fgbio/pull/467

I wanted the tool name and CLI signature to resemble FgBio's ecosystem of nearly-complete tooling.